### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 requirements=[
     'kubernetes',
-	'azure'
+	'azure==4.0.0'
 ]
 
 setup(


### PR DESCRIPTION
 Starting with v5.0.0, the 'azure' meta-package is deprecated and cannot be installed anymore.